### PR TITLE
feat: add Czech (cs) i18n localization and modular language detection

### DIFF
--- a/src/archi_mcp/i18n/languages/__init__.py
+++ b/src/archi_mcp/i18n/languages/__init__.py
@@ -2,10 +2,12 @@
 
 from .english import ENGLISH_DICT
 from .slovak import SLOVAK_DICT
+from .czech import CZECH_DICT
 
 AVAILABLE_LANGUAGES = {
     "en": ENGLISH_DICT,
     "sk": SLOVAK_DICT,
+    "cs": CZECH_DICT,
 }
 
-__all__ = ["ENGLISH_DICT", "SLOVAK_DICT", "AVAILABLE_LANGUAGES"]
+__all__ = ["ENGLISH_DICT", "SLOVAK_DICT", "CZECH_DICT", "AVAILABLE_LANGUAGES"]

--- a/src/archi_mcp/i18n/languages/czech.py
+++ b/src/archi_mcp/i18n/languages/czech.py
@@ -1,0 +1,96 @@
+"""Czech language dictionary."""
+
+CZECH_DICT = {
+    "layers": {
+        "Business": "Obchodní vrstva",
+        "Application": "Aplikační vrstva", 
+        "Technology": "Technologická vrstva",
+        "Physical": "Fyzická vrstva",
+        "Motivation": "Motivační vrstva",
+        "Strategy": "Strategická vrstva",
+        "Implementation": "Implementační vrstva"
+    },
+    "relationships": {
+        "Access": "přístup",
+        "Aggregation": "agregace",
+        "Assignment": "přiřazení",
+        "Association": "asociace", 
+        "Composition": "kompozice",
+        "Flow": "tok",
+        "Influence": "ovlivnění",
+        "Realization": "realizace",
+        "Serving": "podpora",
+        "Specialization": "specializace",
+        "Triggering": "spuštění"
+    },
+    "elements": {
+        # Business Layer
+        "Business_Actor": "Obchodní aktér",
+        "Business_Role": "Obchodní role",
+        "Business_Collaboration": "Obchodní spolupráce",
+        "Business_Interface": "Obchodní rozhraní",
+        "Business_Function": "Obchodní funkce",
+        "Business_Process": "Obchodní proces",
+        "Business_Event": "Obchodní událost",
+        "Business_Service": "Obchodní služba",
+        "Business_Object": "Obchodní objekt",
+        "Business_Contract": "Obchodní smlouva",
+        "Business_Representation": "Obchodní reprezentace",
+        "Location": "Umístění",
+        
+        # Application Layer
+        "Application_Component": "Aplikační komponenta",
+        "Application_Collaboration": "Aplikační spolupráce",
+        "Application_Interface": "Aplikační rozhraní",
+        "Application_Function": "Aplikační funkce",
+        "Application_Interaction": "Aplikační interakce",
+        "Application_Process": "Aplikační proces",
+        "Application_Event": "Aplikační událost",
+        "Application_Service": "Aplikační služba",
+        "Application_DataObject": "Dátový objekt",
+        
+        # Technology Layer
+        "Technology_Node": "Uzel",
+        "Technology_Device": "Zařízení",
+        "Technology_SystemSoftware": "Systémový software",
+        "Technology_Interface": "Technologické rozhraní",
+        "Technology_Function": "Technologická funkce",
+        "Technology_Process": "Technologický proces",
+        "Technology_Event": "Technologická událost",
+        "Technology_Service": "Technologická služba",
+        "Technology_Artifact": "Artefakt",
+        "Technology_Collaboration": "Technologická spolupráce",
+        "Communication_Network": "Komunikační síť",
+        
+        # Physical Layer
+        "Distribution_Network": "Distribuční síť",
+        "Equipment": "Vybavení",
+        "Facility": "Prostředí",
+        "Material": "Materiál",
+        
+        # Motivation Layer
+        "Stakeholder": "Zainteresovaná osoba",
+        "Driver": "Motivátor",
+        "Assessment": "Vyhodnocení",
+        "Goal": "Cíl",
+        "Outcome": "Výstup",
+        "Principle": "Princip",
+        "Requirement": "Požadavek",
+        "Constraint": "Omezení",
+        "Meaning": "Význam",
+        "Value": "Hodnota",
+        
+        # Strategy Layer
+        "Resource": "Zdroj",
+        "Capability": "Schopnost",
+        "Value_Stream": "Hodnotový tok",
+        "Course_of_Action": "Směr postupu",
+        
+        # Implementation Layer
+        "Work_Package": "Pracovní balík",
+        "Deliverable": "Dodaný výstup",
+        "Implementation_Event": "Implementační událost",
+        "Plateau": "Stabilní stav",
+        "Gap": "Rozdíl"
+    }
+}

--- a/src/archi_mcp/server.py
+++ b/src/archi_mcp/server.py
@@ -41,62 +41,69 @@ from .archimate import (
 from .archimate.elements.base import ArchiMateLayer, ArchiMateAspect
 from .i18n import ArchiMateTranslator, AVAILABLE_LANGUAGES
 
-def detect_language_from_content(diagram) -> str:
-    """Automatically detect language from diagram content.
-    
-    Args:
-        diagram: DiagramInput with elements and relationships
-        
-    Returns:
-        Language code (e.g., "sk", "en")
-    """
-    # Slovak language indicators
-    slovak_indicators = [
-        # Common Slovak words
+LANGUAGE_INDICATORS = {
+    "sk": [
         'zákazník', 'podpora', 'služba', 'proces', 'objekt', 'komponent',
         'podnikový', 'zákaznícky', 'proaktívna', 'inteligentý', 'znalostná',
         'konverzačná', 'vylepšený', 'starostlivosť', 'riešenie', 'problémov',
         'schopnosť', 'platforma', 'báza', 'profil', 'analýza', 'nálady',
         'spokojnosť', 'sledovanie', 'emócií', 'monitoruje', 'aktualizuje',
         'pristupuje', 'spúšťa', 'umožňuje', 'napájaný', 'asistovaný',
-        # Slovak diacritics patterns
         'ň', 'ť', 'ž', 'č', 'š', 'ľ', 'ý', 'á', 'í', 'é', 'ó', 'ú', 'ô'
-    ]
-    
+    ],
+    "cs": [
+        'zákazník', 'podpora', 'služba', 'proces', 'objekt', 'komponenta',
+        'podnikový', 'zákaznícký', 'proaktívní', 'inteligentní', 'znalostní',
+        'konverzační', 'vylepšený', 'starostlivost', 'řešení', 'problémů',
+        'schopnost', 'platforma', 'báze', 'profil', 'analýza', 'nálady',
+        'spokojnost', 'sledování', 'emocí', 'monitoruje', 'aktualizuje',
+        'přistupuje', 'spouští', 'umožňuje', 'napájený', 'asistovaný',
+        'á', 'č', 'ď', 'é', 'ě', 'í', 'ň', 'ó', 'ř', 'š', 'ť', 'ú', 'ů', 'ž'
+    ],
+}
+
+LANGUAGE_DETECTION_THRESHOLD = 3
+
+def detect_language_from_content(diagram) -> str:
+    """Automatically detect language from diagram content.
+
+    Args:
+        diagram: DiagramInput with elements and relationships
+
+    Returns:
+        Language code (e.g., "sk", "cs", "en")
+    """
     # Collect all text content
     all_text = []
-    
-    # Add element names and descriptions
+
     for element in diagram.elements:
         if element.name:
             all_text.append(element.name.lower())
         if element.description:
             all_text.append(element.description.lower())
-    
-    # Add relationship labels and descriptions
+
     for rel in diagram.relationships:
         if rel.label:
             all_text.append(rel.label.lower())
         if rel.description:
             all_text.append(rel.description.lower())
-    
-    # Add title and description
+
     if diagram.title:
         all_text.append(diagram.title.lower())
     if diagram.description:
         all_text.append(diagram.description.lower())
-    
-    # Join all text
+
     content = ' '.join(all_text)
-    
-    # Count Slovak indicators
-    slovak_score = sum(1 for indicator in slovak_indicators if indicator in content)
-    
-    # If significant Slovak content detected, return Slovak
-    if slovak_score >= 3:  # Threshold for Slovak detection
-        return "sk"
-    
-    # Default to English
+
+    scores = {
+        lang: sum(1 for indicator in indicators if indicator in content)
+        for lang, indicators in LANGUAGE_INDICATORS.items()
+    }
+
+    best_lang = max(scores, key=lambda lang: scores[lang])
+    if scores[best_lang] >= LANGUAGE_DETECTION_THRESHOLD:
+        return best_lang
+
     return "en"
 
 def override_relationship_labels_with_translations(diagram, translator: ArchiMateTranslator) -> None:

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -92,6 +92,56 @@ class TestLanguageDetection:
         language = detect_language_from_content(diagram)
         assert language == "sk"
 
+    def test_detect_language_from_content_czech(self):
+        """Test Czech language detection with various indicators."""
+        from archi_mcp.server import DiagramInput, ElementInput, RelationshipInput, detect_language_from_content
+
+        diagram = DiagramInput(
+            title="Zákaznická podpora služba",
+            description="Proaktívní starostlivost o zákazníky",
+            elements=[
+                ElementInput(
+                    id="customer",
+                    name="Zákazník",
+                    element_type="Business_Actor",
+                    layer="Business",
+                    description="Podnikový zákaznícký objekt"
+                )
+            ],
+            relationships=[
+                RelationshipInput(
+                    id="rel1",
+                    from_element="customer",
+                    to_element="service",
+                    relationship_type="Access",
+                    label="přistupuje"
+                )
+            ]
+        )
+
+        language = detect_language_from_content(diagram)
+        assert language == "cs"
+
+    def test_detect_language_minimal_czech(self):
+        """Test Czech detection with Czech-specific indicators."""
+        from archi_mcp.server import DiagramInput, ElementInput, detect_language_from_content
+
+        diagram = DiagramInput(
+            elements=[
+                ElementInput(
+                    id="test",
+                    name="řešení sledování",
+                    element_type="Business_Actor",
+                    layer="Business",
+                    description="schopnost komponenta báze"
+                )
+            ],
+            relationships=[]
+        )
+
+        language = detect_language_from_content(diagram)
+        assert language == "cs"
+
 
 class TestCustomRelationshipValidation:
     """Test custom relationship name validation logic."""


### PR DESCRIPTION
- Add CZECH_DICT with translations for all 55+ elements, 7 layers, and 11 relationship types, sourced from the OpenGroup ArchiMate 3.2 Translation Glossary: English-Czech
- Register Czech ("cs") in AVAILABLE_LANGUAGES alongside English and Slovak
- Extend detect_language_from_content() to recognise Czech via unique words and diacritics (ě, ř, ů), distinguishing it from Slovak
- Refactor language detection into a module-level LANGUAGE_INDICATORS dict and a generic score loop — adding a new language now requires only one dict entry with no changes to detection logic
- Add two Czech detection tests mirroring the existing Slovak test pattern

Author: Vilém Charwot <vilem.charwot@proton.me>